### PR TITLE
Refactor C++ and R interface for L2 regression functions (switch to double precision, native Rcpp exports)

### DIFF
--- a/R/solver.R
+++ b/R/solver.R
@@ -25,7 +25,7 @@ ridgeRegression = function(X, Y, Sk, gamma, lambda, n, p, k, trans = FALSE, spar
     X = t(X)
     Y = t(Y)
   }
-  fit = .Call("L2Regression", X, Y, Sk, gamma, lambda, n, p, k, PACKAGE = "ssemQr")
+  fit = L2Regression(X, Y, Sk, gamma, lambda, n, p, k)
   if (sparse) {
     fit$F = Matrix(fit$F, sparse = T)
   }
@@ -357,16 +357,16 @@ opt.SSEMiPALM = function(X, Y, B, F, Sk, sigma2, Wb = NULL, Wf = NULL, nlambda =
     for (ilambda in 1:nlambda) {
       if (ilambda == 1) {
         fit[[j]] = SSEMiPALM(X = X, Y = Y, B = B, F = F, Sk = Sk, sigma2 = sigma2,
-                         lambda = Inf, rho = rho, Wb = Wb, Wf = Wf, p = p, maxit = 200,
-                         threshold = 1e-4, trans = TRUE, strict = FALSE, verbose = FALSE)
+                             lambda = Inf, rho = rho, Wb = Wb, Wf = Wf, p = p, maxit = 200,
+                             threshold = 1e-4, trans = TRUE, strict = FALSE, verbose = FALSE)
         lambda_max = initLambdaSSEM2B(X, Y, fit[[j]], Wb)
         lambda_factors = 10 ** seq(0, -3, length.out = nlambda) * lambda_max
         cat(sprintf("SSEM@lambda = %4f, rho = %4f\n", lambda_factors[ilambda], rho))
 
       } else {
         fit[[j]] = SSEMiPALM(X = X, Y = Y, B = B, F = F, Sk = Sk, sigma2 = sigma2,
-                         lambda = lambda_factors[ilambda], rho = rho, Wb = Wb, Wf = Wf,
-                         p = p, maxit = 200, threshold = 1e-4, trans = TRUE, strict = FALSE, verbose = FALSE)
+                             lambda = lambda_factors[ilambda], rho = rho, Wb = Wb, Wf = Wf,
+                             p = p, maxit = 200, threshold = 1e-4, trans = TRUE, strict = FALSE, verbose = FALSE)
         cat(sprintf("SSEM@lambda = %4f, rho = %4f\n", lambda_factors[ilambda], rho))
       }
       fit[[j]]$B[abs(fit[[j]]$B) < 1e-3] = 0

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,7 +10,7 @@ obj.ridgeRegression = function(X, Y, fit, trans = F) {
     X = t(X)
     Y = t(Y)
   }
-  error = .Call("ObjL2Regression", X, Y, fit, PACKAGE = "ssemQr")
+  error = ObjL2Regression(X, Y, fit)
   error
 }
 
@@ -22,7 +22,7 @@ obj.ridgeRegression = function(X, Y, fit, trans = F) {
 lamax.ridgeRegression = function(X, Y, Sk, n, p, k) {
   X = t(X)
   Y = t(Y)
-  lambda = .Call("L2lamax", X, Y, Sk, n, p, k, PACKAGE = "ssemQr")
+  lambda = L2lamax(X, Y, Sk, n, p, k)
   lambda
 }
 
@@ -295,7 +295,7 @@ downloadGTExv6p = function (type = "genes", file = NULL, ...)
   }
   message("Creating ExpressionSet")
   pdfinal <- pdfinal[match(colnames(counts), rownames(pdfinal)),
-                     ]
+  ]
   es <- Biobase::ExpressionSet(as.matrix(counts))
   Biobase::phenoData(es) <- pdfinal
   pData(es)["GTEX-YF7O-2326-101833-SM-5CVN9", "SMTS"] <- "Skin"

--- a/src/LR.h
+++ b/src/LR.h
@@ -24,7 +24,6 @@ inline double LR_Trace(MatType& Xi, MatType& Yi, MatType& yi) {
   return E.eigenvalues().maxCoeff();
 }
 
-
 template<class MatType>
 inline MatType LR_Fi(MatType& Xi, MatType& Yi, MatType& yi, MatType& bi, const double lambda) {
   MatType H = Xi.transpose() * Xi;
@@ -46,14 +45,14 @@ inline double LR_Objerr(MatType& X, MatType& Y, MatType& B, MatType& F, MatType&
 
 template<class MatType, class VecType, class IdxType>
 inline double L2lr(MatType& X, MatType& Y, IdxType& S, MatType& B, VecType& fi, MatType& mu, const double gamma, const double lambda, const int n, const int p, const int k) {
-  MatrixXf xm, ym;
+  MatType xm, ym;
   center(X, xm);
   center(Y, ym);
-  MatrixXf Xi, Yi, yi, bi, xi;
+  MatType Xi, Yi, yi, bi, xi;
   fi.resize(p);
   double error = 0, sigma2;
 #ifdef _OPENMP
-  #pragma omp parallel for private(Xi, Yi, yi, bi) shared(B, fi) reduction(+:error)
+#pragma omp parallel for private(Xi, Yi, yi, bi) shared(B, fi) reduction(+:error)
 #endif
   for(int i = 1; i <= p; i++)
   {
@@ -65,9 +64,9 @@ inline double L2lr(MatType& X, MatType& Y, IdxType& S, MatType& B, VecType& fi, 
     fi[i-1] = LR_Fi(Xi, Yi, yi, bi, lambda);
     error += (yi - Yi * bi - Xi * fi[i-1]).squaredNorm();
   }
-  mu  = (MatrixXf::Identity(p, p) - B) * ym;
+  mu  = (MatType::Identity(p, p) - B) * ym;
 #ifdef _OPENMP
-  #pragma omp parallel for private(xi) shared(mu)
+#pragma omp parallel for private(xi) shared(mu)
 #endif
   for (int i = 1; i <= p; i++) {
     xi = get_Rows(xm, S[i-1]);
@@ -78,13 +77,13 @@ inline double L2lr(MatType& X, MatType& Y, IdxType& S, MatType& B, VecType& fi, 
 
 template<class MatType, class IdxType>
 inline double L2lamax(MatType& X, MatType& Y, IdxType& S, const int n, const int p, const int k) {
-  MatrixXf xm, ym;
+  MatType xm, ym;
   center(X, xm);
   center(Y, ym);
-  MatrixXf Xi, Yi, yi;
+  MatType Xi, Yi, yi;
   double lambda = 0;
 #ifdef _OPENMP
-  #pragma omp parallel for private(Xi, Yi, yi) reduction(max:lambda)
+#pragma omp parallel for private(Xi, Yi, yi) reduction(max:lambda)
 #endif
   for(int i = 1; i <= p; i++)
   {

--- a/src/ssemQr.cpp
+++ b/src/ssemQr.cpp
@@ -1,29 +1,63 @@
+// src/ssemQr.cpp
+#include <Rcpp.h>
+#include <RcppEigen.h>
 #include "MatOp.h"
 #include "LR.h"
+#include <vector>
+#include <cmath>
 
-RcppExport SEXP L2Regression(SEXP X_, SEXP Y_, SEXP S_, SEXP gamma_, SEXP lambda_, SEXP n_, SEXP p_, SEXP k_)
+using namespace Rcpp;
+using Eigen::ArrayXi;
+using Eigen::Map;
+using Eigen::VectorXi;
+using Eigen::MatrixXd;
+
+// [[Rcpp::export]]
+SEXP L2Regression(SEXP X_, SEXP Y_, SEXP S_, SEXP gamma_, SEXP lambda_, SEXP n_, SEXP p_, SEXP k_)
 {
-BEGIN_RCPP
-  MatrixXf X = Rcpp::as<MatrixXf>(X_);
-  MatrixXf Y = Rcpp::as<MatrixXf>(Y_);
-  std::vector<ArrayXd> S = Rcpp::as<std::vector<ArrayXd> >(S_);
+  BEGIN_RCPP
+  // Convert inputs
+  MatrixXd X = Rcpp::as<MatrixXd>(X_);
+  MatrixXd Y = Rcpp::as<MatrixXd>(Y_);
+  Rcpp::List Slist(S_);
+  std::vector<ArrayXi> S;
+  S.reserve(Slist.size());
+  for (int i = 0; i < Slist.size(); ++i) {
+    IntegerVector vi = Slist[i];
+    // map IntegerVector to Eigen::VectorXi and then to ArrayXi
+    Map<VectorXi> m(vi.begin(), vi.size());
+    ArrayXi ai = m.array();
+    S.push_back(ai);
+  }
+
   const double gamma  = Rcpp::as<double>(gamma_);
   const double lambda = Rcpp::as<double>(lambda_);
   const int n = Rcpp::as<int>(n_);
   const int p = Rcpp::as<int>(p_);
   const int k = Rcpp::as<int>(k_);
-  MatrixXf B;
-  std::vector<MatrixXf> f;
-  MatrixXf F;
-  MatrixXf mu;
-  double error2 = 0, df = 0;
+
+  // outputs / temporaries
+  MatrixXd B;
+  std::vector<MatrixXd> f;
+  MatrixXd F;
+  MatrixXd mu;
+  double error2 = 0.0, df = 0.0;
+
   B.resize(p, p);
   B.setZero();
   f.resize(p);
-  error2 = L2lr(X, Y, S, B, f, mu, gamma, lambda, n, p, k);
-  df = n * p - 1;
+
+  // Call templated routine (explicit template args to help deduction)
+  error2 = L2lr<MatrixXd, std::vector<MatrixXd>, std::vector<ArrayXi>>(
+    X, Y, S, B, f, mu, gamma, lambda, n, p, k
+  );
+
+  df = static_cast<double>(n) * static_cast<double>(p) - 1.0;
   double sigma2 = error2 / df;
-  F = get_Fs(f, S, k).transpose();
+
+  // get_Fs expects the fi vector and S; returns a p x k matrix (MatType)
+  F = get_Fs<MatrixXd, std::vector<ArrayXi>>(f, S, k).transpose();
+
   return Rcpp::List::create(
     Rcpp::Named("B") = B,
     Rcpp::Named("f") = f,
@@ -31,38 +65,48 @@ BEGIN_RCPP
     Rcpp::Named("mu") = mu,
     Rcpp::Named("sigma2") = sigma2
   );
-END_RCPP
+  END_RCPP
 }
 
-RcppExport SEXP ObjL2Regression(SEXP X_, SEXP Y_, SEXP fit_)
+// [[Rcpp::export]]
+SEXP ObjL2Regression(SEXP X_, SEXP Y_, SEXP fit_)
 {
-BEGIN_RCPP
-  MatrixXf X = Rcpp::as<MatrixXf>(X_);
-  MatrixXf Y = Rcpp::as<MatrixXf>(Y_);
+  BEGIN_RCPP
+  MatrixXd X = Rcpp::as<MatrixXd>(X_);
+  MatrixXd Y = Rcpp::as<MatrixXd>(Y_);
   Rcpp::List fit(fit_);
-  MatrixXf B = Rcpp::as<MatrixXf>(fit["B"]);
-  MatrixXf F = Rcpp::as<MatrixXf>(fit["F"]);
-  MatrixXf mu = Rcpp::as<MatrixXf>(fit["mu"]);
-  double error2 = 0;
-  error2 += LR_Objerr(X, Y, B, F, mu);
+  MatrixXd B = Rcpp::as<MatrixXd>(fit["B"]);
+  MatrixXd F = Rcpp::as<MatrixXd>(fit["F"]);
+  MatrixXd mu = Rcpp::as<MatrixXd>(fit["mu"]);
+  double error2 = 0.0;
+  error2 += LR_Objerr<MatrixXd>(X, Y, B, F, mu);
   double err = std::sqrt(error2);
   return Rcpp::wrap(err);
-  //return Rcpp::wrap(error2);
-END_RCPP
+  END_RCPP
 }
 
-RcppExport SEXP L2lamax(SEXP X_, SEXP Y_, SEXP S_, SEXP n_, SEXP p_, SEXP k_)
+// [[Rcpp::export]]
+SEXP L2lamax(SEXP X_, SEXP Y_, SEXP S_, SEXP n_, SEXP p_, SEXP k_)
 {
-BEGIN_RCPP
-  MatrixXf X = Rcpp::as<MatrixXf>(X_);
-  MatrixXf Y = Rcpp::as<MatrixXf>(Y_);
-  std::vector<ArrayXd>  S  = Rcpp::as<std::vector<ArrayXd> >(S_);
+  BEGIN_RCPP
+  MatrixXd X = Rcpp::as<MatrixXd>(X_);
+  MatrixXd Y = Rcpp::as<MatrixXd>(Y_);
+
+  Rcpp::List Slist(S_);
+  std::vector<ArrayXi> S;
+  S.reserve(Slist.size());
+  for (int i = 0; i < Slist.size(); ++i) {
+    IntegerVector vi = Slist[i];
+    Map<VectorXi> m(vi.begin(), vi.size());
+    ArrayXi ai = m.array();
+    S.push_back(ai);
+  }
+
   const int n = Rcpp::as<int>(n_);
   const int p = Rcpp::as<int>(p_);
   const int k = Rcpp::as<int>(k_);
-  double lambda = 0;
-  lambda = L2lamax(X, Y, S, n, p, k);
+  double lambda = 0.0;
+  lambda = L2lamax<MatrixXd, std::vector<ArrayXi>>(X, Y, S, n, p, k);
   return Rcpp::wrap(lambda);
-END_RCPP
+  END_RCPP
 }
-


### PR DESCRIPTION
This pull request refactors several components of the `ssemQr` package to improve numerical precision, modernize the Rcpp interface, and enhance code maintainability and compilability.
The main updates replace single-precision (`float`) Eigen matrices with double-precision (`double`) equivalents, remove outdated `.Call()` wrappers, and rely on `// [[Rcpp::export]]` for cleaner R-C++ integration.

**Details**

**1. R/solver.R**
 - Replaced the `.Call("L2Regression", ...)` interface with a direct call to the exported `L2Regression()` function.
 - Simplified function call to ensure compatibility with the updated Rcpp interface.

**2. R/utils.R**
 - Replaced `.Call("ObjL2Regression", ...)` and `.Call("L2lamax", ...)` by direct Rcpp exports.
 - Ensured all `L2` routines are now called via the modern Rcpp mechanism.

**3. src/ssemQr.cpp**
 - Major refactor from `MatrixXf` (float) to `MatrixXd` (double) for better numerical precision.
 - Replaced manual SEXP parsing with idiomatic Rcpp + Eigen type conversions.
 - Added `//[[Rcpp::export]]` to `L2Regression`, `ObjL2Regression`, and `L2lamax`.
 - Rewrote handling of list-type inputs using `std::vector<ArrayXi>` instead of `std::vector<ArrayXd>` for integer indexing. 

**src/LR.h**
 - Replaced all `MatrixXf/VectorXf` types with template-consistent MatType.
 - Ensured consistent use of MatType in `L2lr `and `L2lamax`.
 - Fixed identity matrix generation (`MatType::Identity`).

**src/MatOp.h**
 - Unified index access using `ix[i]` instead of `ix(i)`, improving compatibility with `std::vector` and `ArrayXi`.
 - Changed iteration variable types (`size_t`) for safety.
 - Updated centering function to use `double` and `std::bind` with `std::minus<float>` instead of deprecated `bind2nd`.

**Testing**

- [x] Successfully compiled on both Linux (Ubuntu 22.04.5 LTS) and Windows 11 environments without errors or warnings.
- [x] Confirmed that the Rmarkdown example included in the package documentation (model with simulated data) runs to completion without issues and reproduces expected results.